### PR TITLE
MemosとNewsのリストコンポーネントを共通化

### DIFF
--- a/src/components/CardList.astro
+++ b/src/components/CardList.astro
@@ -1,0 +1,109 @@
+---
+export interface CardItem {
+  id: string;
+  title: string;
+  description?: string;
+  pubDate: Date;
+  tags?: string[];
+  href: string;
+}
+
+interface Props {
+  items: CardItem[];
+  showTags?: boolean;
+  class?: string;
+}
+
+const { items, showTags = false, class: className } = Astro.props;
+---
+
+<ul class:list={["card-list", className]}>
+  {
+    items.map((item) => (
+      <li data-tags={item.tags?.join(',')}>
+        <a href={item.href}>
+          <h2>{item.title}</h2>
+          {item.description && <p>{item.description}</p>}
+          <time datetime={item.pubDate.toISOString()}>
+            {item.pubDate.toLocaleDateString('ja-JP')}
+          </time>
+          {showTags && item.tags && item.tags.length > 0 && (
+            <div class="tags">
+              {item.tags.map((tag) => (
+                <span class="tag">{tag}</span>
+              ))}
+            </div>
+          )}
+        </a>
+      </li>
+    ))
+  }
+</ul>
+
+<style>
+  .card-list {
+    list-style: none;
+    margin-top: 2rem;
+  }
+
+  .card-list li {
+    margin-bottom: 1.5rem;
+  }
+
+  .card-list li.hidden {
+    display: none;
+  }
+
+  .card-list a {
+    display: block;
+    padding: 1rem;
+    border: 1px solid #eee;
+    border-radius: 8px;
+    text-decoration: none;
+    color: inherit;
+    transition: border-color 0.2s;
+  }
+
+  .card-list a:hover {
+    border-color: #ccc;
+  }
+
+  .card-list h2 {
+    font-size: 1.125rem;
+    margin-bottom: 0.5rem;
+    color: #0066cc;
+  }
+
+  .card-list p {
+    color: #666;
+    margin-bottom: 0.5rem;
+  }
+
+  time {
+    color: #999;
+    font-size: 0.875rem;
+  }
+
+  .tags {
+    margin-top: 0.5rem;
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .tag {
+    font-size: 0.75rem;
+    padding: 0.125rem 0.5rem;
+    background: #f0f0f0;
+    border-radius: 4px;
+  }
+
+  @media (max-width: 480px) {
+    .card-list h2 {
+      font-size: 1rem;
+    }
+
+    .card-list a {
+      padding: 0.75rem;
+    }
+  }
+</style>

--- a/src/pages/memos/index.astro
+++ b/src/pages/memos/index.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../../layouts/Layout.astro';
+import CardList from '../../components/CardList.astro';
 import { getCollection } from 'astro:content';
 
 const memos = await getCollection('memos', ({ data }) => !data.draft);
@@ -9,6 +10,16 @@ const sortedMemos = memos.sort(
 
 // 全タグを取得（重複除去してソート）
 const allTags = [...new Set(memos.flatMap((m) => m.data.tags))].sort();
+
+// CardList用にデータを変換
+const items = sortedMemos.map((memo) => ({
+  id: memo.id,
+  title: memo.data.title,
+  description: memo.data.description,
+  pubDate: memo.data.pubDate,
+  tags: memo.data.tags,
+  href: `/memos/${memo.id}`,
+}));
 
 const PER_PAGE = 20;
 ---
@@ -26,28 +37,7 @@ const PER_PAGE = 20;
     </div>
   )}
 
-  <ul class="memos-list">
-    {
-      sortedMemos.map((memo) => (
-        <li data-tags={memo.data.tags.join(',')}>
-          <a href={`/memos/${memo.id}`}>
-            <h2>{memo.data.title}</h2>
-            {memo.data.description && <p>{memo.data.description}</p>}
-            <time datetime={memo.data.pubDate.toISOString()}>
-              {memo.data.pubDate.toLocaleDateString('ja-JP')}
-            </time>
-            {memo.data.tags.length > 0 && (
-              <div class="tags">
-                {memo.data.tags.map((tag) => (
-                  <span class="tag">{tag}</span>
-                ))}
-              </div>
-            )}
-          </a>
-        </li>
-      ))
-    }
-  </ul>
+  <CardList items={items} showTags={true} />
 
   <div class="pagination">
     <button class="page-btn" id="prev-btn" disabled>&larr; Prev</button>
@@ -82,62 +72,6 @@ const PER_PAGE = 20;
     background: #333;
     color: white;
     border-color: #333;
-  }
-
-  .memos-list {
-    list-style: none;
-    margin-top: 2rem;
-  }
-
-  .memos-list li {
-    margin-bottom: 1.5rem;
-  }
-
-  .memos-list li.hidden {
-    display: none;
-  }
-
-  .memos-list a {
-    display: block;
-    padding: 1rem;
-    border: 1px solid #eee;
-    border-radius: 8px;
-    text-decoration: none;
-    color: inherit;
-    transition: border-color 0.2s;
-  }
-
-  .memos-list a:hover {
-    border-color: #ccc;
-  }
-
-  .memos-list h2 {
-    font-size: 1.125rem;
-    margin-bottom: 0.5rem;
-    color: #0066cc;
-  }
-
-  .memos-list p {
-    color: #666;
-    margin-bottom: 0.5rem;
-  }
-
-  time {
-    color: #999;
-    font-size: 0.875rem;
-  }
-
-  .tags {
-    margin-top: 0.5rem;
-    display: flex;
-    gap: 0.5rem;
-  }
-
-  .tag {
-    font-size: 0.75rem;
-    padding: 0.125rem 0.5rem;
-    background: #f0f0f0;
-    border-radius: 4px;
   }
 
   .pagination {
@@ -177,7 +111,7 @@ const PER_PAGE = 20;
 </style>
 
 <script define:vars={{ PER_PAGE }}>
-  const allItems = Array.from(document.querySelectorAll('.memos-list li'));
+  const allItems = Array.from(document.querySelectorAll('.card-list li'));
   const filterTags = document.querySelectorAll('.filter-tag');
   const prevBtn = document.getElementById('prev-btn');
   const nextBtn = document.getElementById('next-btn');

--- a/src/pages/news/index.astro
+++ b/src/pages/news/index.astro
@@ -1,81 +1,118 @@
 ---
 import Layout from '../../layouts/Layout.astro';
+import CardList from '../../components/CardList.astro';
 import { getCollection } from 'astro:content';
 
 const news = await getCollection('news', ({ data }) => !data.draft);
 const sortedNews = news.sort(
   (a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime()
 );
+
+// CardList用にデータを変換
+const items = sortedNews.map((item) => ({
+  id: item.id,
+  title: item.data.title,
+  description: item.data.description,
+  pubDate: item.data.pubDate,
+  href: `/news/${item.id}`,
+}));
+
+const PER_PAGE = 20;
 ---
 
 <Layout title="News | kouno.log">
   <h1>News</h1>
   <p>お知らせ一覧</p>
 
-  <ul class="news-list">
-    {
-      sortedNews.map((item) => (
-        <li>
-          <a href={`/news/${item.id}`}>
-            <h2>{item.data.title}</h2>
-            {item.data.description && <p>{item.data.description}</p>}
-            <time datetime={item.data.pubDate.toISOString()}>
-              {item.data.pubDate.toLocaleDateString('ja-JP')}
-            </time>
-          </a>
-        </li>
-      ))
-    }
-  </ul>
+  <CardList items={items} />
+
+  <div class="pagination">
+    <button class="page-btn" id="prev-btn" disabled>&larr; Prev</button>
+    <span class="page-info" id="page-info">1 / 1</span>
+    <button class="page-btn" id="next-btn">Next &rarr;</button>
+  </div>
 </Layout>
 
 <style>
-  .news-list {
-    list-style: none;
+  .pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
     margin-top: 2rem;
+    padding-top: 1rem;
+    border-top: 1px solid #eee;
   }
 
-  .news-list li {
-    margin-bottom: 1.5rem;
+  .page-btn {
+    padding: 0.5rem 1rem;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    background: white;
+    cursor: pointer;
+    font-size: 0.875rem;
+    transition: all 0.2s;
   }
 
-  .news-list a {
-    display: block;
-    padding: 1rem;
-    border: 1px solid #eee;
-    border-radius: 8px;
-    text-decoration: none;
-    color: inherit;
-    transition: border-color 0.2s;
+  .page-btn:hover:not(:disabled) {
+    border-color: #999;
+    background: #f5f5f5;
   }
 
-  .news-list a:hover {
-    border-color: #ccc;
+  .page-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 
-  .news-list h2 {
-    font-size: 1.125rem;
-    margin-bottom: 0.5rem;
-    color: #0066cc;
-  }
-
-  .news-list p {
+  .page-info {
     color: #666;
-    margin-bottom: 0.5rem;
-  }
-
-  time {
-    color: #999;
     font-size: 0.875rem;
   }
-
-  @media (max-width: 480px) {
-    .news-list h2 {
-      font-size: 1rem;
-    }
-
-    .news-list a {
-      padding: 0.75rem;
-    }
-  }
 </style>
+
+<script define:vars={{ PER_PAGE }}>
+  const allItems = Array.from(document.querySelectorAll('.card-list li'));
+  const prevBtn = document.getElementById('prev-btn');
+  const nextBtn = document.getElementById('next-btn');
+  const pageInfo = document.getElementById('page-info');
+
+  let currentPage = 1;
+
+  function updateDisplay() {
+    const totalPages = Math.ceil(allItems.length / PER_PAGE) || 1;
+
+    const start = (currentPage - 1) * PER_PAGE;
+    const end = start + PER_PAGE;
+
+    allItems.forEach((item, index) => {
+      if (index >= start && index < end) {
+        item.classList.remove('hidden');
+      } else {
+        item.classList.add('hidden');
+      }
+    });
+
+    pageInfo.textContent = `${currentPage} / ${totalPages}`;
+    prevBtn.disabled = currentPage <= 1;
+    nextBtn.disabled = currentPage >= totalPages;
+  }
+
+  prevBtn.addEventListener('click', () => {
+    if (currentPage > 1) {
+      currentPage--;
+      updateDisplay();
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  });
+
+  nextBtn.addEventListener('click', () => {
+    const totalPages = Math.ceil(allItems.length / PER_PAGE) || 1;
+    if (currentPage < totalPages) {
+      currentPage++;
+      updateDisplay();
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  });
+
+  updateDisplay();
+</script>


### PR DESCRIPTION
## Summary
- CardList.astroコンポーネントを新規作成し、MemosとNewsページで共通利用
- Newsページにもページネーション機能を追加
- 重複していたスタイルを共通コンポーネントに集約

## Changes
- `src/components/CardList.astro` - 新規作成
  - カードリスト表示の共通コンポーネント
  - `showTags`プロパティでタグ表示の切り替え可能
  - レスポンシブスタイル対応
- `src/pages/memos/index.astro` - CardListコンポーネントを使用するよう変更
- `src/pages/news/index.astro` - CardListコンポーネントを使用 + ページネーション追加

## Test plan
- [ ] Memosページのカード表示が正常に動作する
- [ ] Memosページのタグフィルターが正常に動作する
- [ ] Memosページのページネーションが正常に動作する
- [ ] Newsページのカード表示が正常に動作する
- [ ] Newsページのページネーションが正常に動作する
- [ ] ビルドが成功する

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)