### PR TITLE
Cloudflareアダプターの画像サービス警告を解消

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,7 +9,9 @@ import sitemap from '@astrojs/sitemap';
 // https://astro.build/config
 export default defineConfig({
   site: 'https://kouno-log.pages.dev',
-  adapter: cloudflare(),
+  adapter: cloudflare({
+    imageService: 'compile',
+  }),
   integrations: [sitemap()],
   markdown: {
     // rehypePlugins: [


### PR DESCRIPTION
## Summary
- ビルド時に出ていたCloudflareアダプターの警告を解消

## Changes
- `astro.config.mjs`のcloudflare()アダプターに`imageService: 'compile'`オプションを追加

## Before
```
[WARN] [adapter] Cloudflare does not support sharp at runtime. However, you can configure `imageService: "compile"` to optimize images with sharp on prerendered pages during build time.
```

## After
警告が出なくなる

## Test plan
- [x] ビルドが成功する
- [x] 警告が出なくなることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)