### PR TITLE
メモのタグフィルターを利用数順+上位8件+もっと見るに変更

### DIFF
--- a/e2e/pages.spec.ts
+++ b/e2e/pages.spec.ts
@@ -46,6 +46,26 @@ test.describe('メモ一覧 (/memos)', () => {
     const articles = page.locator('main a[href^="/memos/"]');
     await expect(articles.first()).toBeVisible();
   });
+
+  test('タグフィルターに件数が表示される', async ({ page }) => {
+    await page.goto('/memos');
+    const filter = page.locator('.tag-filter');
+    await expect(filter.locator('.filter-btn[data-tag=""]')).toHaveText('All');
+    await expect(filter.locator('.filter-btn[data-tag]').nth(1)).toContainText(/\(\d+\)$/);
+  });
+
+  test('「もっと見る」で残りのタグを展開できる', async ({ page }) => {
+    await page.goto('/memos');
+    const toggle = page.locator('#tag-toggle');
+    const extraBtn = page.locator('#extra-tags .filter-btn').first();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(extraBtn).toBeHidden();
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    await expect(extraBtn).toBeVisible();
+    await toggle.click();
+    await expect(extraBtn).toBeHidden();
+  });
 });
 
 test.describe('外部記事一覧 (/external)', () => {

--- a/src/content/memos/api-endpoints-for-ai-cli.md
+++ b/src/content/memos/api-endpoints-for-ai-cli.md
@@ -2,7 +2,7 @@
 title: Cloudflare Pages上のAstroサイトでJSON APIを作る
 description: Cloudflare Pages上のAstroサイトにJSON APIを追加した際のハマりどころをまとめる
 pubDate: 2026-04-07
-tags: [Astro, Cloudflare Pages]
+tags: [Astro, Cloudflare]
 ---
 
 AI CLI（Claude Codeなど）から自分のアウトプットを参照できる環境を作りたくて、kouno.logにJSON APIを追加した。追加したエンドポイントの詳細は「[kouno.log に API エンドポイントを追加しました](/news/api-endpoints)」の記事を参照。

--- a/src/content/memos/astro-site-shell-monorepo.md
+++ b/src/content/memos/astro-site-shell-monorepo.md
@@ -2,7 +2,7 @@
 title: astro-site-shell をモノレポ化してコアロジックを切り出した
 description: Astro コンポーネントに混在していたバニラ JS ロジックを site-shell-core として分離し、フレームワーク非依存なパッケージに切り出した話
 pubDate: 2026-05-09
-tags: [astro, npm, typescript, monorepo]
+tags: [Astro, npm, TypeScript, monorepo]
 ---
 
 # astro-site-shell をモノレポ化してコアロジックを切り出した

--- a/src/content/memos/chira-ura-tech-stack.md
+++ b/src/content/memos/chira-ura-tech-stack.md
@@ -2,7 +2,7 @@
 title: chira-ura.netの技術スタック
 description: 個人サイトプラットフォーム「チラ裏」の技術選定と構成を解説
 pubDate: 2026-03-28
-tags: [nuxt, hono, supabase, cloudflare]
+tags: [Nuxt, Hono, Supabase, Cloudflare]
 ---
 
 # chira-ura.netの技術スタック

--- a/src/content/memos/cloudflare-pages-skip-ci.md
+++ b/src/content/memos/cloudflare-pages-skip-ci.md
@@ -2,7 +2,7 @@
 title: Cloudflare Pagesのデプロイがスキップされていた件
 description: コミットメッセージに[Skip CI]をつけるとCloudflare Pagesのデプロイがスキップされる
 pubDate: 2026-01-27
-tags: [Cloudflare Pages]
+tags: [Cloudflare]
 ---
 
 # Cloudflare Pagesのデプロイがスキップされていた件

--- a/src/content/memos/naze-naze-tech-stack.md
+++ b/src/content/memos/naze-naze-tech-stack.md
@@ -2,7 +2,7 @@
 title: なぜなぜ分析ツールの技術スタック
 description: ツリー構造となぜなぜ分析の因果検証をサポートするWebアプリの技術選定と設計を解説
 pubDate: 2026-04-26
-tags: [react, typescript, react-flow, vite, tailwind]
+tags: [React, TypeScript, React Flow, Vite, Tailwind CSS]
 ---
 
 # なぜなぜ分析ツールの技術スタック

--- a/src/content/memos/rough-table.md
+++ b/src/content/memos/rough-table.md
@@ -2,7 +2,7 @@
 title: 手書き風テーブルライブラリ「rough-table」を作った
 description: Rough.jsを使ってHTMLテーブルに手書き風ボーダーを描画するvanilla JSライブラリを公開した
 pubDate: 2026-04-02
-tags: [javascript, oss, rough-table]
+tags: [JavaScript, OSS, rough-table]
 ---
 
 # 手書き風テーブルライブラリ「rough-table」を作った

--- a/src/content/memos/system-architecture.md
+++ b/src/content/memos/system-architecture.md
@@ -2,7 +2,7 @@
 title: kouno.logのシステム構成
 description: このサイトの技術スタックと構成について
 pubDate: 2026-01-19
-tags: [astro, cloudflare]
+tags: [Astro, Cloudflare]
 ---
 
 # kouno.logのシステム構成

--- a/src/content/memos/unagi-tasks.md
+++ b/src/content/memos/unagi-tasks.md
@@ -2,7 +2,7 @@
 title: 判断コストゼロを目指すTODOアプリ「Unagi Tasks」を作った
 description: タスクを自動スコアリングして今やるべき1件だけを表示するTODOアプリをDeno / Fresh 2で作った
 pubDate: 2026-04-15
-tags: [deno, fresh, preact, tailwindcss, todo]
+tags: [Deno, Fresh, Preact, Tailwind CSS, todo]
 ---
 
 # 判断コストゼロを目指すTODOアプリ「Unagi Tasks」を作った

--- a/src/pages/memos/index.astro
+++ b/src/pages/memos/index.astro
@@ -8,8 +8,21 @@ const sortedMemos = memos.sort(
   (a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime()
 );
 
-// 全タグを取得（重複除去してソート）
-const allTags = [...new Set(memos.flatMap((m) => m.data.tags))].sort();
+// タグを利用数（記事数）順に集計。同数はアルファベット順
+const tagCounts = new Map<string, number>();
+for (const memo of memos) {
+  for (const tag of memo.data.tags) {
+    tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
+  }
+}
+const sortedTags = [...tagCounts.entries()].sort(
+  ([tagA, countA], [tagB, countB]) => countB - countA || tagA.localeCompare(tagB)
+);
+
+// 上位のみ常時表示し、残りは「もっと見る」で展開
+const VISIBLE_TAG_COUNT = 8;
+const visibleTags = sortedTags.slice(0, VISIBLE_TAG_COUNT);
+const extraTags = sortedTags.slice(VISIBLE_TAG_COUNT);
 
 // CardList用にデータを変換
 const items = sortedMemos.map((memo) => ({
@@ -28,12 +41,27 @@ const PER_PAGE = 20;
   <h1>Memos</h1>
   <p>メモ書き・記事一覧</p>
 
-  {allTags.length > 0 && (
+  {sortedTags.length > 0 && (
     <div class="tag-filter">
       <button class="filter-btn active" data-tag="">All</button>
-      {allTags.map((tag) => (
-        <button class="filter-btn" data-tag={tag}>{tag}</button>
+      {visibleTags.map(([tag, count]) => (
+        <button class="filter-btn" data-tag={tag}>{tag} ({count})</button>
       ))}
+      {extraTags.length > 0 && (
+        <>
+          <div class="extra-tags" id="extra-tags" hidden>
+            {extraTags.map(([tag, count]) => (
+              <button class="filter-btn" data-tag={tag}>{tag} ({count})</button>
+            ))}
+          </div>
+          <button
+            class="filter-btn tag-toggle"
+            id="tag-toggle"
+            aria-expanded="false"
+            aria-controls="extra-tags"
+          >もっと見る (+{extraTags.length})</button>
+        </>
+      )}
     </div>
   )}
 
@@ -53,14 +81,30 @@ const PER_PAGE = 20;
     margin: 1.5rem 0;
     flex-wrap: wrap;
   }
+
+  /* 展開時は中のボタンを親のflexにそのまま流し込む */
+  .extra-tags {
+    display: contents;
+  }
+
+  .extra-tags[hidden] {
+    display: none;
+  }
+
+  .tag-toggle {
+    border-style: dashed;
+  }
 </style>
 
 <script define:vars={{ PER_PAGE }}>
   const allItems = Array.from(document.querySelectorAll('.card-list li'));
-  const filterTags = document.querySelectorAll('.filter-btn');
+  const filterTags = document.querySelectorAll('.filter-btn[data-tag]');
   const prevBtn = document.getElementById('prev-btn');
   const nextBtn = document.getElementById('next-btn');
   const pageInfo = document.getElementById('page-info');
+  const extraTags = document.getElementById('extra-tags');
+  const tagToggle = document.getElementById('tag-toggle');
+  const tagToggleLabel = tagToggle?.textContent;
 
   // URLからタグを取得
   const urlParams = new URLSearchParams(window.location.search);
@@ -70,11 +114,27 @@ const PER_PAGE = 20;
   let currentTag = initialTag;
   let filteredItems = allItems;
 
+  function setExtraTagsExpanded(expanded) {
+    if (!extraTags || !tagToggle) return;
+    extraTags.hidden = !expanded;
+    tagToggle.setAttribute('aria-expanded', String(expanded));
+    tagToggle.textContent = expanded ? '閉じる' : tagToggleLabel;
+  }
+
+  tagToggle?.addEventListener('click', () => {
+    setExtraTagsExpanded(extraTags.hidden);
+  });
+
   // 初期タグがあればボタンのactiveを更新
   if (initialTag) {
     filterTags.forEach((btn) => {
       btn.classList.toggle('active', btn.dataset.tag === initialTag);
     });
+    // 初期タグが折りたたみ内にあれば展開しておく
+    const isExtra = [...filterTags].some(
+      (btn) => btn.dataset.tag === initialTag && extraTags?.contains(btn)
+    );
+    if (isExtra) setExtraTagsExpanded(true);
   }
 
   function getFilteredItems() {


### PR DESCRIPTION
Closes #143

## 変更内容

### タグフィルターUI（`src/pages/memos/index.astro`）
- タグを利用数（記事数）順にソート。同数はアルファベット順（`localeCompare`）でタイブレーク
- 上位8件を常時表示し、残りは「もっと見る (+N)」ボタンで展開（`aria-expanded`/`aria-controls`付き、展開後は「閉じる」）
- 各タグボタンに件数を表示（例: `Astro (3)`）
- `?tag=` で指定されたタグが折りたたみ内にある場合は初期表示で自動展開

### タグの表記ゆれ正規化（frontmatter修正）
集計を正確にするため、8ファイルのタグ表記を統一:
- `astro` → `Astro` / `typescript` → `TypeScript` / `deno` → `Deno` / `fresh` → `Fresh`
- `cloudflare` / `Cloudflare Pages` → `Cloudflare` に統合
- あわせて `nuxt`→`Nuxt`、`react`→`React`、`tailwind`/`tailwindcss`→`Tailwind CSS` など固有名詞を公式表記に統一

正規化後は24種類（分裂解消前は28種類相当）。上位8件はちょうど利用数2件以上のタグ（Cloudflare 4 / TypeScript 4 / Astro 3 / Deno Deploy 3 / Deno 2 / Fresh 2 / GitHub Actions 2 / Tailwind CSS 2）。

### E2E
- タグフィルターの件数表示と「もっと見る」展開/折りたたみのテストを追加

## 確認
- `pnpm lint` / `pnpm build` パス
- `pnpm test:e2e` 19件すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)